### PR TITLE
Wrap README prose at 80 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ To package this buildpack for consumption:
 ./scripts/package.sh --version 2.2.6
 ```
 
-This will build the buildpack for all target architectures specified in `buildpack.toml` (amd64 and arm64 by default) and create a single archive containing binaries for all architectures in the `build/` directory.
+This will build the buildpack for all target architectures specified in
+`buildpack.toml` (amd64 and arm64 by default) and create a single archive
+containing binaries for all architectures in the `build/` directory.
 
 This will create a `buildpackage.cnb` file under the `build` directory which you
 can use to build your app as follows:
@@ -66,7 +68,8 @@ pack build <app-name> \
   --buildpack <path/to/cnb-that-requires-node-and-yarn>
 ```
 
-Though the API of this buildpack does not require `node`, yarn is unusable without node.
+Though the API of this buildpack does not require `node`, yarn is unusable
+without node.
 
 ## Publishing
 
@@ -86,7 +89,8 @@ aws ecr get-login-password --region us-east-1 | \
 The script will automatically:
 - Read target architectures from `buildpack.toml`
 - Extract the buildpack archive
-- Publish each architecture separately with arch-suffixed tags (e.g., `yarn:<version>-amd64`, `yarn:<version>-arm64`)
+- Publish each architecture separately with arch-suffixed tags (e.g.,
+  `yarn:<version>-amd64`, `yarn:<version>-arm64`)
 - Create and push a multi-arch manifest list
 
 ## Usage


### PR DESCRIPTION
Wraps prose in `README.md` at 80 columns so it stops scrolling
horizontally in editors without soft wrap.

Only paragraph text is rewrapped. Code blocks, tables, headings, URLs and
HTML are left byte for byte alone, and the rendered output is unchanged.

Opened by `gh-repo-compliancy`.
