### PR TITLE
Revert "Wrap README prose at 80 columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ To package this buildpack for consumption:
 ./scripts/package.sh --version 2.2.6
 ```
 
-This will build the buildpack for all target architectures specified in
-`buildpack.toml` (amd64 and arm64 by default) and create a single archive
-containing binaries for all architectures in the `build/` directory.
+This will build the buildpack for all target architectures specified in `buildpack.toml` (amd64 and arm64 by default) and create a single archive containing binaries for all architectures in the `build/` directory.
 
 This will create a `buildpackage.cnb` file under the `build` directory which you
 can use to build your app as follows:
@@ -68,8 +66,7 @@ pack build <app-name> \
   --buildpack <path/to/cnb-that-requires-node-and-yarn>
 ```
 
-Though the API of this buildpack does not require `node`, yarn is unusable
-without node.
+Though the API of this buildpack does not require `node`, yarn is unusable without node.
 
 ## Publishing
 
@@ -89,8 +86,7 @@ aws ecr get-login-password --region us-east-1 | \
 The script will automatically:
 - Read target architectures from `buildpack.toml`
 - Extract the buildpack archive
-- Publish each architecture separately with arch-suffixed tags (e.g.,
-  `yarn:<version>-amd64`, `yarn:<version>-arm64`)
+- Publish each architecture separately with arch-suffixed tags (e.g., `yarn:<version>-amd64`, `yarn:<version>-arm64`)
 - Create and push a multi-arch manifest list
 
 ## Usage


### PR DESCRIPTION
**Description**

- Removed: reverts the 80-column README prose wrapping.

Restores `README.md` to its content from before the wrap commit, taken from git
history (the parent of that commit) rather than from a working copy.

Reverting so the wrapping can be redone at 120 columns from the original text.
Re-wrapping the already-wrapped file is not equivalent — wrapping at 80 can
split a line so short that re-wrapping at 120 cannot rejoin it, which affects 5
of 266 READMEs. Going back to the original avoids that.

Only `README.md` is touched.

**Checklist**

- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary label (patch/minor/major - If package publish is required).
- [x] I have followed the suggested description format and styling.

**Reviewers**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
